### PR TITLE
Create downloader for Github daily dumps from GHTorrent

### DIFF
--- a/downloaders/dumps_downloader.py
+++ b/downloaders/dumps_downloader.py
@@ -46,18 +46,23 @@ def process_archives(archive_links: [str], target_dir: str) -> None:
                                        reporthook=download_progress_hook(p_bar))
 
         unique_dump_dir = os.path.join(target_dir, tar_filename.replace(".tar.gz", ""))
-        untar(target_loc, unique_dump_dir)
-        remove_excess_files(os.path.join(unique_dump_dir, "dump/github"))
+        is_successful_untar = untar(target_loc, unique_dump_dir)
+        if is_successful_untar:
+            remove_excess_files(os.path.join(unique_dump_dir, "dump/github"))
 
 
-def untar(tarfile_path: str, target_directory: str, remove_tarfile: bool = True) -> None:
+def untar(tarfile_path: str, target_directory: str, remove_tarfile: bool = True) -> bool:
     os.makedirs(target_directory, exist_ok=True)
     with tarfile.open(tarfile_path, "r:gz") as tar:
-        for member in tqdm(desc="extracting %s" % tarfile_path, iterable=tar.getmembers(),
-                           total=len(tar.getmembers())):
-            tar.extract(path=target_directory, member=member)
+        try:
+            for member in tqdm(desc="extracting %s" % tarfile_path, iterable=tar.getmembers(),
+                               total=len(tar.getmembers())):
+                tar.extract(path=target_directory, member=member)
+        except EOFError:
+            return False
     if remove_tarfile:
         os.remove(tarfile_path)
+    return True
 
 
 def remove_excess_files(directory: str) -> None:

--- a/downloaders/dumps_downloader.py
+++ b/downloaders/dumps_downloader.py
@@ -1,0 +1,76 @@
+import urllib.request
+import tarfile
+import sys
+import os
+from bs4 import BeautifulSoup
+
+
+def show_file_progress(block_num, block_size, total_size):
+    downloaded = block_num * block_size
+    if total_size > 0:
+        percent = downloaded * 1e2 / total_size
+        s = "\r%5.1f%% %*d / %d bytes" % (percent, len(str(total_size)), downloaded, total_size)
+        sys.stderr.write(s)
+        if downloaded >= total_size:
+            sys.stderr.write("\n")
+
+
+def get_tar_files_links_from_html(url):
+    html_page = urllib.request.urlopen(url)
+    soup = BeautifulSoup(html_page, features='html.parser')
+    tar_files_links = []
+    for link in soup.findAll('a', href=True):
+        filename = link.get('href')
+        if filename.endswith('tar.gz'):
+            tar_files_links.append(url + filename)
+    return tar_files_links
+
+
+def extract_tar_files_to_directory(tar_files_links, target_dir):
+    create_directory_if_not_exists(target_dir)
+    for tar_file_link in tar_files_links:
+        tar_filename = os.path.basename(tar_file_link)
+        full_tar_filename = target_dir + '/' + tar_filename
+
+        print("downloading %s file" % tar_filename)
+        urllib.request.urlretrieve(tar_file_link, full_tar_filename, show_file_progress)
+
+        unique_dump_dir = target_dir + '/' + tar_filename.replace('.tar.gz', '')
+        extract_tar_to_directory(full_tar_filename, unique_dump_dir, True)
+        remove_excess_files(unique_dump_dir + '/dump/github')
+
+
+def extract_tar_to_directory(tarfile_path, target_directory, need_remove_tarfile):
+    if tarfile_path.endswith('tar.gz'):
+        print("extracting %s file" % tarfile_path)
+        tar = tarfile.open(tarfile_path, 'r:gz')
+        create_directory_if_not_exists(target_directory)
+        tar.extractall(target_directory)
+        tar.close()
+        if need_remove_tarfile:
+            os.remove(tarfile_path)
+
+
+def remove_excess_files(directory):
+    issue_connected_files = ['issues.bson', 'issue_comments.bson']
+    bson_files = os.listdir(directory)
+    for cur_bson_file in bson_files:
+        if cur_bson_file not in issue_connected_files:
+            os.remove(directory + "/" + cur_bson_file)
+
+
+def create_directory_if_not_exists(dir_path):
+    if not os.path.exists(dir_path):
+        os.makedirs(dir_path)
+
+
+def main():
+    url = "http://ghtorrent-downloads.ewi.tudelft.nl/mongo-daily/"
+    tar_files_links = get_tar_files_links_from_html(url)
+
+    download_target_dir = os.path.abspath(os.getcwd()) + '/data'
+    extract_tar_files_to_directory(tar_files_links, download_target_dir)
+
+
+if __name__ == '__main__':
+    main()

--- a/downloaders/dumps_downloader.py
+++ b/downloaders/dumps_downloader.py
@@ -1,5 +1,6 @@
 import tarfile
 import os
+import argparse
 from typing import Optional
 
 import urllib.request
@@ -68,11 +69,14 @@ def remove_excess_files(directory: str) -> None:
 
 
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-t", "--target-dir", required=True,
+                        help="Directory to store downloaded tar files")
+    args = parser.parse_args()
     url = "http://ghtorrent-downloads.ewi.tudelft.nl/mongo-daily/"
     tar_files_links = extract_archive_links(url)
 
-    download_target_dir = os.path.abspath(os.getcwd()) + "/data"
-    process_archives(tar_files_links, download_target_dir)
+    process_archives(tar_files_links, args.target_dir)
 
 
 if __name__ == "__main__":

--- a/downloaders/dumps_downloader.py
+++ b/downloaders/dumps_downloader.py
@@ -21,11 +21,11 @@ def download_progress_hook(p_bar: tqdm) -> (int, int, Optional[int]):
 
 def extract_archive_links(url: str) -> [str]:
     html_page = urllib.request.urlopen(url)
-    soup = BeautifulSoup(html_page, features='html.parser')
+    soup = BeautifulSoup(html_page, features="html.parser")
     tar_files_links = []
-    for link in soup.findAll('a', href=True):
-        filename = link.get('href')
-        if filename.endswith('tar.gz'):
+    for link in soup.findAll("a", href=True):
+        filename = link.get("href")
+        if filename.endswith("tar.gz"):
             tar_files_links.append(url + filename)
     return tar_files_links
 
@@ -34,21 +34,21 @@ def process_archives(archive_links: [str], target_dir: str) -> None:
     os.makedirs(target_dir, exist_ok=True)
     for archive_link in tqdm(archive_links):
         tar_filename = os.path.basename(archive_link)
-        target_loc = target_dir + '/' + tar_filename
+        target_loc = target_dir + "/" + tar_filename
 
         print("downloading %s file" % tar_filename)
         with tqdm() as p_bar:
             urllib.request.urlretrieve(archive_link, filename=target_loc,
                                        reporthook=download_progress_hook(p_bar))
-        unique_dump_dir = target_dir + '/' + tar_filename.replace('.tar.gz', '')
+        unique_dump_dir = target_dir + "/" + tar_filename.replace(".tar.gz", "")
         untar(target_loc, unique_dump_dir)
-        remove_excess_files(unique_dump_dir + '/dump/github')
+        remove_excess_files(unique_dump_dir + "/dump/github")
 
 
 def untar(tarfile_path: str, target_directory: str, remove_tarfile: bool = True) -> None:
-    if tarfile_path.endswith('tar.gz'):
+    if tarfile_path.endswith("tar.gz"):
         print("extracting %s file" % tarfile_path)
-        tar = tarfile.open(tarfile_path, 'r:gz')
+        tar = tarfile.open(tarfile_path, "r:gz")
         os.makedirs(target_directory, exist_ok=True)
         tar.extractall(target_directory)
         tar.close()
@@ -57,7 +57,7 @@ def untar(tarfile_path: str, target_directory: str, remove_tarfile: bool = True)
 
 
 def remove_excess_files(directory: str) -> None:
-    issue_related_files = {'issues.bson', 'issue_comments.bson'}
+    issue_related_files = {"issues.bson", "issue_comments.bson"}
     bson_files = os.listdir(directory)
     for file in bson_files:
         if file not in issue_related_files:
@@ -68,9 +68,9 @@ def main():
     url = "http://ghtorrent-downloads.ewi.tudelft.nl/mongo-daily/"
     tar_files_links = extract_archive_links(url)
 
-    download_target_dir = os.path.abspath(os.getcwd()) + '/data'
+    download_target_dir = os.path.abspath(os.getcwd()) + "/data"
     process_archives(tar_files_links, download_target_dir)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/downloaders/dumps_downloader.py
+++ b/downloaders/dumps_downloader.py
@@ -34,15 +34,15 @@ def process_archives(archive_links: [str], target_dir: str) -> None:
     os.makedirs(target_dir, exist_ok=True)
     for archive_link in tqdm(archive_links):
         tar_filename = os.path.basename(archive_link)
-        target_loc = target_dir + "/" + tar_filename
+        target_loc = os.path.join(target_dir, tar_filename)
 
         print("downloading %s file" % tar_filename)
         with tqdm() as p_bar:
             urllib.request.urlretrieve(archive_link, filename=target_loc,
                                        reporthook=download_progress_hook(p_bar))
-        unique_dump_dir = target_dir + "/" + tar_filename.replace(".tar.gz", "")
+        unique_dump_dir = os.path.join(target_dir, tar_filename.replace(".tar.gz", ""))
         untar(target_loc, unique_dump_dir)
-        remove_excess_files(unique_dump_dir + "/dump/github")
+        remove_excess_files(os.path.join(unique_dump_dir, "dump/github"))
 
 
 def untar(tarfile_path: str, target_directory: str, remove_tarfile: bool = True) -> None:
@@ -61,7 +61,7 @@ def remove_excess_files(directory: str) -> None:
     bson_files = os.listdir(directory)
     for file in bson_files:
         if file not in issue_related_files:
-            os.remove(directory + "/" + file)
+            os.remove(os.path.join(directory, file))
 
 
 def main():

--- a/downloaders/dumps_downloader.py
+++ b/downloaders/dumps_downloader.py
@@ -2,14 +2,14 @@
 Download Github issues daily dumps from this page
 "http://ghtorrent-downloads.ewi.tudelft.nl/mongo-daily/" and store them into target directory.
 """
-import tarfile
-import os
 import argparse
+import os
+import tarfile
 from typing import Optional
 
-import urllib.request
 from bs4 import BeautifulSoup
 from tqdm import tqdm
+import urllib.request
 
 
 def download_progress_hook(p_bar: tqdm) -> (int, int, Optional[int]):

--- a/downloaders/dumps_downloader.py
+++ b/downloaders/dumps_downloader.py
@@ -1,3 +1,7 @@
+"""
+Download Github issues daily dumps from this page
+"http://ghtorrent-downloads.ewi.tudelft.nl/mongo-daily/" and store them into target directory.
+"""
 import tarfile
 import os
 import argparse
@@ -9,10 +13,22 @@ from tqdm import tqdm
 
 
 def download_progress_hook(p_bar: tqdm) -> (int, int, Optional[int]):
+    """
+    Wraps tqdm instance
+    :param p_bar: tqdm instance responible for showing download progress
+    :return: function update_to which updates tqdm state
+    """
     last_block = [0]
 
     def update_to(block_num: int = 1, block_size: int = 1,
                   total_size: Optional[int] = None) -> None:
+        """
+        Update tqdm state
+        :param block_num: Number of blocks transferred so far
+        :param block_size: Size of each block
+        :param total_size: Total size (in tqdm units)
+        :return: None
+        """
         if total_size not in (None, -1):
             p_bar.total = total_size
         p_bar.update((block_num - last_block[0]) * block_size)
@@ -22,6 +38,11 @@ def download_progress_hook(p_bar: tqdm) -> (int, int, Optional[int]):
 
 
 def extract_archive_links(url: str) -> [str]:
+    """
+    Extract tar files links from GHTorrent html page to list
+    :param url: url of page with daily dumps tars
+    :return: list of tar files links
+    """
     html_page = urllib.request.urlopen(url)
     soup = BeautifulSoup(html_page, features="html.parser")
     tar_files_links = []
@@ -33,6 +54,12 @@ def extract_archive_links(url: str) -> [str]:
 
 
 def process_archives(archive_links: [str], target_dir: str) -> None:
+    """
+    Download tar files and untar them to target directory
+    :param archive_links: list of tar files links
+    :param target_dir: target directory
+    :return: None
+    """
     os.makedirs(target_dir, exist_ok=True)
     for archive_link in tqdm(desc="process archives", iterable=archive_links,
                              total=len(archive_links)):
@@ -52,6 +79,13 @@ def process_archives(archive_links: [str], target_dir: str) -> None:
 
 
 def untar(tarfile_path: str, target_directory: str, remove_tarfile: bool = True) -> bool:
+    """
+    Untar tarfile to target directory and remove tarfile if it is necessary
+    :param tarfile_path: path of tarfile
+    :param target_directory: directory where files will be extracted
+    :param remove_tarfile: True if necessary to remove tarfile, otherwise - False
+    :return: True if untar process was successful, else - False
+    """
     os.makedirs(target_directory, exist_ok=True)
     with tarfile.open(tarfile_path, "r:gz") as tar:
         try:
@@ -66,6 +100,11 @@ def untar(tarfile_path: str, target_directory: str, remove_tarfile: bool = True)
 
 
 def remove_excess_files(directory: str) -> None:
+    """
+    Remove all files from directory, except for related to issues
+    :param directory: directory where excess files will be deleted
+    :return: None
+    """
     issue_related_files = {"issues.bson", "issue_comments.bson"}
     bson_files = os.listdir(directory)
     for file in bson_files:
@@ -73,7 +112,11 @@ def remove_excess_files(directory: str) -> None:
             os.remove(os.path.join(directory, file))
 
 
-def main():
+def main() -> None:
+    """
+    Download and untar Github daily dumps tar files to target_dir
+    :return: None
+    """
     parser = argparse.ArgumentParser()
     parser.add_argument("-t", "--target-dir", required=True,
                         help="Directory to store downloaded tar files")

--- a/downloaders/dumps_downloader.py
+++ b/downloaders/dumps_downloader.py
@@ -5,14 +5,14 @@ Download Github issues daily dumps from this page
 import argparse
 import os
 import tarfile
-from typing import Optional
+from typing import List, Callable, Optional
 
 from bs4 import BeautifulSoup
 from tqdm import tqdm
 import urllib.request
 
 
-def download_progress_hook(p_bar: tqdm) -> (int, int, Optional[int]):
+def download_progress_hook(p_bar: tqdm) -> Callable[[int, int, Optional[int]], None]:
     """
     Wraps tqdm instance
     :param p_bar: tqdm instance responible for showing download progress
@@ -37,7 +37,7 @@ def download_progress_hook(p_bar: tqdm) -> (int, int, Optional[int]):
     return update_to
 
 
-def extract_archive_links(url: str) -> [str]:
+def extract_archive_links(url: str) -> List[str]:
     """
     Extract tar files links from GHTorrent html page to list
     :param url: url of page with daily dumps tars
@@ -53,7 +53,7 @@ def extract_archive_links(url: str) -> [str]:
     return tar_files_links
 
 
-def process_archives(archive_links: [str], target_dir: str) -> None:
+def process_archives(archive_links: List[str], target_dir: str) -> None:
     """
     Download tar files and untar them to target directory
     :param archive_links: list of tar files links

--- a/downloaders/dumps_downloader.py
+++ b/downloaders/dumps_downloader.py
@@ -1,7 +1,8 @@
-import urllib.request
 import tarfile
 import sys
 import os
+
+import urllib.request
 from bs4 import BeautifulSoup
 
 

--- a/downloaders/dumps_downloader.py
+++ b/downloaders/dumps_downloader.py
@@ -1,16 +1,16 @@
 import tarfile
-import sys
 import os
+from typing import Optional
 
 import urllib.request
 from bs4 import BeautifulSoup
 from tqdm import tqdm
 
 
-def download_progress_hook(p_bar: tqdm):
+def download_progress_hook(p_bar: tqdm) -> (int, int, Optional[int]):
     last_block = [0]
 
-    def update_to(block_num: int = 1, block_size: int = 1, total_size: int = None):
+    def update_to(block_num: int = 1, block_size: int = 1, total_size: Optional[int] = None) -> None:
         if total_size not in (None, -1):
             p_bar.total = total_size
         p_bar.update((block_num - last_block[0]) * block_size)
@@ -19,7 +19,7 @@ def download_progress_hook(p_bar: tqdm):
     return update_to
 
 
-def get_tar_files_links_from_html(url):
+def get_tar_files_links_from_html(url: str) -> [str]:
     html_page = urllib.request.urlopen(url)
     soup = BeautifulSoup(html_page, features='html.parser')
     tar_files_links = []
@@ -30,7 +30,7 @@ def get_tar_files_links_from_html(url):
     return tar_files_links
 
 
-def extract_tar_files_to_directory(tar_files_links, target_dir):
+def extract_tar_files_to_directory(tar_files_links: [str], target_dir: str) -> None:
     os.makedirs(target_dir, exist_ok=True)
     for tar_file_link in tar_files_links:
         tar_filename = os.path.basename(tar_file_link)
@@ -45,7 +45,7 @@ def extract_tar_files_to_directory(tar_files_links, target_dir):
         remove_excess_files(unique_dump_dir + '/dump/github')
 
 
-def extract_tar_to_directory(tarfile_path, target_directory, need_remove_tarfile):
+def extract_tar_to_directory(tarfile_path: str, target_directory: str, need_remove_tarfile: bool) -> None:
     if tarfile_path.endswith('tar.gz'):
         print("extracting %s file" % tarfile_path)
         tar = tarfile.open(tarfile_path, 'r:gz')
@@ -56,7 +56,7 @@ def extract_tar_to_directory(tarfile_path, target_directory, need_remove_tarfile
             os.remove(tarfile_path)
 
 
-def remove_excess_files(directory):
+def remove_excess_files(directory: str) -> None:
     issue_connected_files = ['issues.bson', 'issue_comments.bson']
     bson_files = os.listdir(directory)
     for cur_bson_file in bson_files:

--- a/downloaders/dumps_downloader.py
+++ b/downloaders/dumps_downloader.py
@@ -10,7 +10,8 @@ from tqdm import tqdm
 def download_progress_hook(p_bar: tqdm) -> (int, int, Optional[int]):
     last_block = [0]
 
-    def update_to(block_num: int = 1, block_size: int = 1, total_size: Optional[int] = None) -> None:
+    def update_to(block_num: int = 1, block_size: int = 1,
+                  total_size: Optional[int] = None) -> None:
         if total_size not in (None, -1):
             p_bar.total = total_size
         p_bar.update((block_num - last_block[0]) * block_size)
@@ -32,7 +33,8 @@ def extract_archive_links(url: str) -> [str]:
 
 def process_archives(archive_links: [str], target_dir: str) -> None:
     os.makedirs(target_dir, exist_ok=True)
-    for archive_link in tqdm(desc="process archives", iterable=archive_links, total=len(archive_links)):
+    for archive_link in tqdm(desc="process archives", iterable=archive_links,
+                             total=len(archive_links)):
         if not archive_link.endswith("tar.gz"):
             continue
         tar_filename = os.path.basename(archive_link)
@@ -50,7 +52,8 @@ def process_archives(archive_links: [str], target_dir: str) -> None:
 def untar(tarfile_path: str, target_directory: str, remove_tarfile: bool = True) -> None:
     os.makedirs(target_directory, exist_ok=True)
     with tarfile.open(tarfile_path, "r:gz") as tar:
-        for member in tqdm(desc="extracting %s" % tarfile_path, iterable=tar.getmembers(), total=len(tar.getmembers())):
+        for member in tqdm(desc="extracting %s" % tarfile_path, iterable=tar.getmembers(),
+                           total=len(tar.getmembers())):
             tar.extract(path=target_directory, member=member)
     if remove_tarfile:
         os.remove(tarfile_path)

--- a/downloaders/dumps_downloader.py
+++ b/downloaders/dumps_downloader.py
@@ -28,7 +28,7 @@ def get_tar_files_links_from_html(url):
 
 
 def extract_tar_files_to_directory(tar_files_links, target_dir):
-    create_directory_if_not_exists(target_dir)
+    os.makedirs(target_dir, exist_ok=True)
     for tar_file_link in tar_files_links:
         tar_filename = os.path.basename(tar_file_link)
         full_tar_filename = target_dir + '/' + tar_filename
@@ -45,7 +45,7 @@ def extract_tar_to_directory(tarfile_path, target_directory, need_remove_tarfile
     if tarfile_path.endswith('tar.gz'):
         print("extracting %s file" % tarfile_path)
         tar = tarfile.open(tarfile_path, 'r:gz')
-        create_directory_if_not_exists(target_directory)
+        os.makedirs(target_directory, exist_ok=True)
         tar.extractall(target_directory)
         tar.close()
         if need_remove_tarfile:
@@ -58,11 +58,6 @@ def remove_excess_files(directory):
     for cur_bson_file in bson_files:
         if cur_bson_file not in issue_connected_files:
             os.remove(directory + "/" + cur_bson_file)
-
-
-def create_directory_if_not_exists(dir_path):
-    if not os.path.exists(dir_path):
-        os.makedirs(dir_path)
 
 
 def main():

--- a/loader/__main__.py
+++ b/loader/__main__.py
@@ -1,0 +1,7 @@
+"""
+Initialize Github dumps loader
+"""
+from .loader import main
+
+if __name__ == "__main__":
+    main()

--- a/loader/loader.py
+++ b/loader/loader.py
@@ -125,7 +125,3 @@ def main() -> None:
     tar_files_links = extract_archive_links(url)
 
     process_archives(tar_files_links, args.target_dir)
-
-
-if __name__ == "__main__":
-    main()

--- a/loader/loader.py
+++ b/loader/loader.py
@@ -76,6 +76,7 @@ def process_archives(archive_links: List[str], target_dir: str) -> None:
         is_successful_untar = untar(target_loc, unique_dump_dir)
         if is_successful_untar:
             remove_excess_files(os.path.join(unique_dump_dir, "dump/github"))
+            tar_directory(unique_dump_dir, os.path.join(target_dir, tar_filename))
 
 
 def untar(tarfile_path: str, target_directory: str, remove_tarfile: bool = True) -> bool:
@@ -97,6 +98,22 @@ def untar(tarfile_path: str, target_directory: str, remove_tarfile: bool = True)
     if remove_tarfile:
         os.remove(tarfile_path)
     return True
+
+
+def tar_directory(dir_path: str, tarfile_path: str, remove_directory: bool = True) -> None:
+    """
+    Tar directory to specific path
+    :param dir_path: path to directory
+    :param tarfile_path: path to created tarfile
+    :param remove_directory: True if necessary to remove tarred directory, otherwise - False
+    :return: None
+    """
+    with tarfile.open(tarfile_path, "w:gz") as tar:
+        for root, dirs, files in os.walk(dir_path):
+            for file in files:
+                tar.add(os.path.join(root, file))
+    if remove_directory:
+        os.system("rm -rf %s" % dir_path)
 
 
 def remove_excess_files(directory: str) -> None:


### PR DESCRIPTION
This script was implemented for downloading issues&issues_comments daily dumps from this link
http://ghtorrent-downloads.ewi.tudelft.nl/mongo-daily/
Also I calculated estimated memory complexity of this files
Total compressed size with all daily dumps(including commits, repo, users and so on)
6890 GB
issues.bson and issues_comments.bson files take approximately 1 % of daily dump file
6890 * 0.01 = 68, 9 GB
And taking into account that compressed algorithms compress in the best scenario about 90% of file size we get required disk space at worst 
68.9 / 0.1 = 689 GB